### PR TITLE
Fix version on pillow dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
     setuptools >=46.4.0
 install_requires =
     pdfminer.six==20220524
-    pillow==10.0.0
+    pillow==11
     reportlab==4.0.4
     black==23.7.0
     ruff==0.0.282


### PR DESCRIPTION
<!--- Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the dispatcher where…", "Improve our handling of…", etc." -->
<!-- For more information on Pull Requests, you can reference here: https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute -->
## Describe your changes
The Pillow library had problems with the release of Python 3.13 due to PEP 667, which enforces stricter safety standards on locals(). This causes the reported error when attempting to install with Pillow versions before 11.0. This fix updates the required version of Pillow to 11.
